### PR TITLE
fix: Add missing offset_encoding

### DIFF
--- a/lua/architext/edit.lua
+++ b/lua/architext/edit.lua
@@ -96,6 +96,6 @@ function M.edit(buf, parser, query, capture_changes, start_row, end_row)
     end
   end
 
-  vim.lsp.util.apply_text_edits(edits, buf)
+  vim.lsp.util.apply_text_edits(edits, buf, 'utf-8')
 end
 return M


### PR DESCRIPTION
`apply_text_edits` now requires the offset encoding to be passed. 