### PR TITLE
fix: Use vim.treesitter.query.parse() to avoid deprecation warning

### DIFF
--- a/lua/architext/query.lua
+++ b/lua/architext/query.lua
@@ -29,7 +29,8 @@ function M.get(parser, query)
     end
   end
 
-  query = ts.parse_query(parser:lang(), query)
+  local parse_query = ts.query.parse or ts.query.parse_query
+  query = parse_query(parser:lang(), query)
   previous_queries[parser:lang()] = query
   return query
 end


### PR DESCRIPTION
fix: https://github.com/neovim/neovim/pull/22761